### PR TITLE
chore: update dependabot schedule to monthly except promptfoo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,16 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    allow:
+      - dependency-name: 'promptfoo'


### PR DESCRIPTION
Updates dependabot schedule to run monthly for all dependencies except promptfoo which remains daily