### PR TITLE
fix: Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -5,6 +5,10 @@
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
 name: Check dist
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/promptfoo/promptfoo-action/security/code-scanning/5](https://github.com/promptfoo/promptfoo-action/security/code-scanning/5)

To fix the issue, add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the tasks performed in the workflow:
- `contents: read` is sufficient for reading repository files.
- `actions: write` is required for uploading artifacts.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`check-dist`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
