### PR TITLE
chore(biome): migrate config to 2.2.4

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
   "files": {
     "maxSize": 2097152,
     "ignoreUnknown": true,


### PR DESCRIPTION
Update Biome configuration schema to match the installed CLI (2.2.4).

Validation:
- Ran `npm run all` (build, biome:check, package, tests)
- All checks passed; tests 67/67

This removes the schema mismatch warning during lint runs.