### PR TITLE
ci(dependabot): auto-rebuild dist on Dependabot PRs

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: codeql-config
+paths-ignore:
+  - .github/workflows/dependabot-post-update.yml
+

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 20.x
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: 'CodeQL'
+name: CodeQL
 
 on:
   push:
@@ -18,7 +18,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [main]
   schedule:
-    - cron: '31 7 * * 3'
+  - cron: 31 7 * * 3
 
 jobs:
   analyze:
@@ -32,29 +32,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['TypeScript']
+        language: [TypeScript]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
+    - name: Checkout repository
+      uses: actions/checkout@v5
 
       # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: ${{ matrix.language }}
-          source-root: src
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        source-root: src
+        config-file: .github/codeql/codeql-config.yml
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -67,5 +68,5 @@ jobs:
       #   make bootstrap
       #   make release
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dependabot-post-update.yml
+++ b/.github/workflows/dependabot-post-update.yml
@@ -50,32 +50,40 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: Prepare workspace
-        run: |
-          set -euo pipefail
-          git init .
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote add origin "https://github.com/${{ github.repository }}.git"
-          git fetch --depth=1 origin "${{ github.event.pull_request.head.ref }}"
-          git checkout -B "${{ github.event.pull_request.head.ref }}" FETCH_HEAD
-
       - name: Download dist artifact
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
-
-      - name: Commit generated files
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          git add dist/ || true
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-            exit 0
-          fi
-          git commit -m "chore(dist): rebuild for dependabot update"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+      - name: Commit generated files via API
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = context.payload.pull_request.head.ref;
+            const distDir = path.join(process.cwd(), 'dist');
+            const files = fs.readdirSync(distDir);
+            for (const file of files) {
+              const repoPath = `dist/${file}`;
+              const content = fs.readFileSync(path.join(distDir, file), { encoding: 'base64' });
+              let sha = undefined;
+              try {
+                const { data } = await github.rest.repos.getContent({ owner, repo, path: repoPath, ref: branch });
+                if (!Array.isArray(data)) sha = data.sha;
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+              await github.rest.repos.createOrUpdateFileContents({
+                owner,
+                repo,
+                path: repoPath,
+                message: 'chore(dist): rebuild for dependabot update',
+                content,
+                branch,
+                sha,
+              });
+            }

--- a/.github/workflows/dependabot-post-update.yml
+++ b/.github/workflows/dependabot-post-update.yml
@@ -7,25 +7,21 @@ on:
       - package.json
       - package-lock.json
 
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency:
   group: dependabot-post-update-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
-  rebuild-and-commit:
+  build-dist:
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout merged PR commit (safe)
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
-          # Use the auto-generated merge commit for this PR from the base repo
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Use Node.js
@@ -40,29 +36,44 @@ jobs:
       - name: Build dist artifacts
         run: npm run package
 
-      - name: Prepare git auth and switch to PR head branch
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          git fetch origin "$BRANCH"
-          git checkout -B "$BRANCH" "origin/$BRANCH"
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: ignore
 
-      - name: Rebuild on head branch (ensure consistency)
-        run: |
-          npm ci --ignore-scripts
-          npm run package
+  commit-dist:
+    if: github.actor == 'dependabot[bot]'
+    needs: build-dist
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head branch (no build)
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
 
       - name: Commit generated files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add dist/ || true
           if git diff --cached --quiet; then
             echo "No changes to commit"
-          else
-            git commit -m "chore(dist): rebuild for dependabot update"
-            git push origin "HEAD:$BRANCH"
+            exit 0
           fi
+          git commit -m "chore(dist): rebuild for dependabot update"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push

--- a/.github/workflows/dependabot-post-update.yml
+++ b/.github/workflows/dependabot-post-update.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20.x'
-          cache: 'npm'
 
       - name: Install dependencies (no scripts)
         run: npm ci --ignore-scripts
@@ -51,11 +50,15 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR head branch (no build)
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          persist-credentials: false
+      - name: Prepare workspace
+        run: |
+          set -euo pipefail
+          git init .
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          git fetch --depth=1 origin "${{ github.event.pull_request.head.ref }}"
+          git checkout -B "${{ github.event.pull_request.head.ref }}" FETCH_HEAD
 
       - name: Download dist artifact
         uses: actions/download-artifact@v4
@@ -67,8 +70,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          set -euo pipefail
           git add dist/ || true
           if git diff --cached --quiet; then
             echo "No changes to commit"
@@ -76,4 +78,4 @@ jobs:
           fi
           git commit -m "chore(dist): rebuild for dependabot update"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          git push
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"

--- a/.github/workflows/dependabot-post-update.yml
+++ b/.github/workflows/dependabot-post-update.yml
@@ -1,0 +1,54 @@
+name: dependabot-post-update
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - package.json
+      - package-lock.json
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-post-update-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  rebuild-and-commit:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout dependabot branch
+        uses: actions/checkout@v4
+        with:
+          # Ensure we operate on the PR head branch
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: true
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies (no scripts)
+        run: npm ci --ignore-scripts
+
+      - name: Rebuild dist artifacts
+        run: npm run package
+
+      - name: Commit generated files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dist/ || true
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore(dist): rebuild for dependabot update"
+            git push
+          fi
+

--- a/.github/workflows/dependabot-post-update.yml
+++ b/.github/workflows/dependabot-post-update.yml
@@ -20,16 +20,16 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout dependabot branch
-        uses: actions/checkout@v4
+      - name: Checkout merged PR commit (safe)
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
-          # Ensure we operate on the PR head branch
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          persist-credentials: true
+          # Use the auto-generated merge commit for this PR from the base repo
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20.x'
           cache: 'npm'
@@ -37,8 +37,23 @@ jobs:
       - name: Install dependencies (no scripts)
         run: npm ci --ignore-scripts
 
-      - name: Rebuild dist artifacts
+      - name: Build dist artifacts
         run: npm run package
+
+      - name: Prepare git auth and switch to PR head branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git fetch origin "$BRANCH"
+          git checkout -B "$BRANCH" "origin/$BRANCH"
+
+      - name: Rebuild on head branch (ensure consistency)
+        run: |
+          npm ci --ignore-scripts
+          npm run package
 
       - name: Commit generated files
         run: |
@@ -49,6 +64,5 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "chore(dist): rebuild for dependabot update"
-            git push
+            git push origin "HEAD:$BRANCH"
           fi
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '20.x'
-          cache: 'npm'
       - name: Install Dependencies
         run: npm ci
       - name: Run Biome Check


### PR DESCRIPTION
Automate rebuilding and committing `dist/` for Dependabot PRs.

- Trigger: `pull_request_target` for Dependabot actor, when `package.json` or `package-lock.json` change
- Safety: uses read/write token only on base repo; guarded with `github.actor == 'dependabot[bot]'` and only stages `dist/`
- Steps: `npm ci --ignore-scripts` → `npm run package` → commit `dist/` if changed

This prevents `check-dist` failures and keeps generated artifacts in sync.