### PR TITLE
fix: Add build step before package in dependabot workflow

### DIFF
--- a/.github/workflows/dependabot-post-update.yml
+++ b/.github/workflows/dependabot-post-update.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Build dist artifacts
-        run: npm run package
+        run: npm run build && npm run package
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Add `npm run build` before `npm run package` in dependabot-post-update.yml
- Fixes MODULE_NOT_FOUND error where ncc cannot find lib/main.js  
- The package step requires TypeScript to be compiled to lib/ first

## Problem
The dependabot workflow was failing with:
```
Error: Cannot find module '/home/runner/work/promptfoo-action/promptfoo-action/lib/main.js'. Please verify that the package.json has a valid "main" entry
```

## Root Cause
The workflow was running `npm run package` directly without first running `npm run build`. The `@vercel/ncc` tool requires the compiled JavaScript files in `/lib/` to exist before it can bundle them into `/dist/`.

## Solution
Changed the build step from:
```yaml
- name: Build dist artifacts
  run: npm run package
```

To:
```yaml
- name: Build dist artifacts
  run: npm run build && npm run package
```

## Test plan
- [x] Verified the fix works locally by testing both scenarios
- [x] Confirmed the error reproduces without the build step
- [x] Verified the fix resolves the error
- [ ] Will be tested by the next dependabot PR

🤖 Generated with [Claude Code](https://claude.ai/code)