### PR TITLE
fix: skip empty commits in dependabot workflow

### DIFF
--- a/.github/scripts/commit-dist-changes.js
+++ b/.github/scripts/commit-dist-changes.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = async ({ github, context }) => {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const branch = context.payload.pull_request.head.ref;
+  const distDir = path.join(process.cwd(), 'dist');
+  const files = fs.readdirSync(distDir);
+  let hasChanges = false;
+
+  for (const file of files) {
+    const repoPath = `dist/${file}`;
+    const content = fs.readFileSync(path.join(distDir, file), {
+      encoding: 'base64',
+    });
+    let sha = undefined;
+    let existingContent = undefined;
+
+    try {
+      const { data } = await github.rest.repos.getContent({
+        owner,
+        repo,
+        path: repoPath,
+        ref: branch,
+      });
+      if (!Array.isArray(data)) {
+        sha = data.sha;
+        existingContent = data.content;
+      }
+    } catch (e) {
+      if (e.status !== 404) throw e;
+    }
+
+    if (existingContent !== content) {
+      hasChanges = true;
+      await github.rest.repos.createOrUpdateFileContents({
+        owner,
+        repo,
+        path: repoPath,
+        message: 'chore(dist): rebuild for dependabot update',
+        content,
+        branch,
+        sha,
+      });
+    }
+  }
+
+  if (!hasChanges) {
+    console.log('No changes detected in dist files, skipping commit');
+  }
+};

--- a/.github/workflows/dependabot-post-update.yml
+++ b/.github/workflows/dependabot-post-update.yml
@@ -67,23 +67,34 @@ jobs:
             const branch = context.payload.pull_request.head.ref;
             const distDir = path.join(process.cwd(), 'dist');
             const files = fs.readdirSync(distDir);
+            let hasChanges = false;
             for (const file of files) {
               const repoPath = `dist/${file}`;
               const content = fs.readFileSync(path.join(distDir, file), { encoding: 'base64' });
               let sha = undefined;
+              let existingContent = undefined;
               try {
                 const { data } = await github.rest.repos.getContent({ owner, repo, path: repoPath, ref: branch });
-                if (!Array.isArray(data)) sha = data.sha;
+                if (!Array.isArray(data)) {
+                  sha = data.sha;
+                  existingContent = data.content;
+                }
               } catch (e) {
                 if (e.status !== 404) throw e;
               }
-              await github.rest.repos.createOrUpdateFileContents({
-                owner,
-                repo,
-                path: repoPath,
-                message: 'chore(dist): rebuild for dependabot update',
-                content,
-                branch,
-                sha,
-              });
+              if (existingContent !== content) {
+                hasChanges = true;
+                await github.rest.repos.createOrUpdateFileContents({
+                  owner,
+                  repo,
+                  path: repoPath,
+                  message: 'chore(dist): rebuild for dependabot update',
+                  content,
+                  branch,
+                  sha,
+                });
+              }
+            }
+            if (!hasChanges) {
+              console.log('No changes detected in dist files, skipping commit');
             }

--- a/.github/workflows/dependabot-post-update.yml
+++ b/.github/workflows/dependabot-post-update.yml
@@ -60,41 +60,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const fs = require('fs');
-            const path = require('path');
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const branch = context.payload.pull_request.head.ref;
-            const distDir = path.join(process.cwd(), 'dist');
-            const files = fs.readdirSync(distDir);
-            let hasChanges = false;
-            for (const file of files) {
-              const repoPath = `dist/${file}`;
-              const content = fs.readFileSync(path.join(distDir, file), { encoding: 'base64' });
-              let sha = undefined;
-              let existingContent = undefined;
-              try {
-                const { data } = await github.rest.repos.getContent({ owner, repo, path: repoPath, ref: branch });
-                if (!Array.isArray(data)) {
-                  sha = data.sha;
-                  existingContent = data.content;
-                }
-              } catch (e) {
-                if (e.status !== 404) throw e;
-              }
-              if (existingContent !== content) {
-                hasChanges = true;
-                await github.rest.repos.createOrUpdateFileContents({
-                  owner,
-                  repo,
-                  path: repoPath,
-                  message: 'chore(dist): rebuild for dependabot update',
-                  content,
-                  branch,
-                  sha,
-                });
-              }
-            }
-            if (!hasChanges) {
-              console.log('No changes detected in dist files, skipping commit');
-            }
+            const script = require('./.github/scripts/commit-dist-changes.js');
+            await script({ github, context });

--- a/.github/workflows/dependabot-post-update.yml
+++ b/.github/workflows/dependabot-post-update.yml
@@ -59,6 +59,4 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const script = require('./.github/scripts/commit-dist-changes.js');
-            await script({ github, context });
+          script: ./.github/scripts/commit-dist-changes.js


### PR DESCRIPTION
## Summary
- Modified the dependabot-post-update workflow to compare existing dist files with newly built ones before committing
- Only commits when actual changes are detected, preventing empty commits

## Changes
- Added content comparison logic to check if dist files have changed
- Track `hasChanges` flag throughout the loop
- Skip commit when no changes are detected