### PR TITLE
fix: checkout repo to load script file in github-script action

### DIFF
--- a/.github/workflows/dependabot-post-update.yml
+++ b/.github/workflows/dependabot-post-update.yml
@@ -55,8 +55,16 @@ jobs:
         with:
           name: dist
           path: dist
+      - name: Checkout repository
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
       - name: Commit generated files via API
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: ./.github/scripts/commit-dist-changes.js
+          script: |
+            const commitDistChanges = require('./.github/scripts/commit-dist-changes.js');
+            await commitDistChanges({ github, context });


### PR DESCRIPTION
## Summary
- Added checkout step before github-script to ensure the script file is available
- Changed script parameter to use require() to load the external script file

## Changes
- Checkout the PR head ref so `.github/scripts/commit-dist-changes.js` is available
- Use `require()` in inline script to load and execute the external file

Fixes the syntax error in #686 where github-script couldn't find the script file.