### PR TITLE
fix: resolve security quality findings

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,5 @@
 name: codeql-config
 paths-ignore:
   - .github/workflows/dependabot-post-update.yml
-
+  # dist/ is the generated action bundle; scan the TypeScript source instead.
+  - dist/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
       },
       "engines": {
         "node": ">=20.0.0",
-        "npm": ">=11.6.4"
+        "npm": ">=11.4.0"
       }
     },
     "node_modules/@actions/core": {
@@ -11558,21 +11558,6 @@
         "node": ">=0.4.10"
       }
     },
-    "node_modules/natural/node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
     "node_modules/negotiator": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
@@ -15335,14 +15320,18 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "optional": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "simple-git": "^3.32.1"
   },
   "overrides": {
-    "@anthropic-ai/sdk": "^0.91.0"
+    "@anthropic-ai/sdk": "^0.91.0",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.13",


### PR DESCRIPTION
## Summary

This PR clears the findings visible from the GitHub Security and quality dashboard for promptfoo-action.

The Code quality page showed 65 open standard findings across 9 CodeQL rules, all located in the checked-in generated `dist/index.js` bundle. The AI findings tab showed 0 findings. Because `dist/` is generated from the TypeScript source and already marked as generated for GitHub linguist, this PR updates the existing CodeQL config to ignore `dist/**` so CodeQL focuses on source rather than bundled output.

The same security area also showed one open Dependabot vulnerability for `uuid` via the dev-only `promptfoo -> @azure/msal-node` path. This PR adds an npm override for `uuid@^14.0.0` and updates the lockfile so both `@azure/msal-node` and `natural` resolve to the patched version.

## Validation

- Authenticated Chrome visit to `/security/quality` and each rule detail page
- Authenticated Chrome visit to `/security/quality/ai-findings`, showing 0 AI findings
- `npm ls uuid promptfoo @azure/msal-node natural --all`
- `npm audit --audit-level=moderate`
- `npm run all`
