### PR TITLE
chore: remove unnecessary anthropic sdk override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -331,6 +331,10 @@
         "win32"
       ]
     },
+    "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/sdk": {
+      "dev": true,
+      "optional": true
+    },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.91.1",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -332,8 +332,26 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/sdk": {
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
       "dev": true,
-      "optional": true
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.91.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "simple-git": "^3.32.1"
   },
   "overrides": {
-    "@anthropic-ai/sdk": "^0.91.0",
     "uuid": "^14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- remove the unnecessary `@anthropic-ai/sdk` npm override from `package.json`
- regenerate `package-lock.json` without the override
- confirm `npm audit --package-lock-only` stays clean after removal

## Verification
- `npm install --package-lock-only`
- `npm audit --package-lock-only --json` (`0` vulnerabilities)

Triggered by Renovate PR promptfoo/promptfoo-action#921.
