### PR TITLE
docs: document pull request title convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,17 @@ The repository also includes a local copy of Promptfoo source under `/promptfoo/
 - Mock external boundaries such as GitHub, filesystem, and git execution.
 - Coverage output is written to `/coverage/`.
 
+### Pull Request Titles
+
+Use Conventional Commits format:
+`<type>(<optional-scope>): <short description>`.
+
+- Begin with a lowercase conventional type such as `feat`, `fix`, `docs`,
+  `test`, `refactor`, `build`, `ci`, or `chore`.
+- Do not add agent or tool prefixes such as `[codex]`. This repository rule
+  overrides generic publishing templates.
+- Describe the primary change, for example: `docs: add security policy`.
+
 ## Release Workflow
 
 1. Make changes and test locally


### PR DESCRIPTION
## Summary

This PR makes the repository's pull request title convention explicit for
agents. Pull request #976 was initially created with a generic `[codex]`
prefix, even though this repository consistently uses Conventional Commits
titles such as `docs:`, `fix:`, and `chore:`.

## Root cause

`AGENTS.md` documented development, testing, and release practices but did not
state the expected pull request title format or explain that repository rules
override generic publishing templates. That left room for an agent tool's
default title format to win over the repository's established convention.

## Fix

The new guidance:

- Requires `<type>(<optional-scope>): <short description>` titles.
- Lists common lowercase conventional types.
- Explicitly rejects agent or tool identity prefixes such as `[codex]`.
- States that the repository rule overrides generic publishing templates.
- Includes a concrete compliant example.

This is separate from #976 so the security-policy PR stays narrowly scoped and
keeps its existing review history intact.

## Validation

- `npm run all`
  - Build, Biome, typecheck, packaging, and tests passed.
  - 9 test files and 236 tests passed.
  - Statement, branch, function, and line coverage remained at 100%.
- `git diff --check`
- Reviewed the 20 most recent merged pull request titles; all use conventional
  `type: description` or `type(scope): description` formatting.
